### PR TITLE
Return the same type as the original data structure

### DIFF
--- a/src/matross/mapstache.clj
+++ b/src/matross/mapstache.clj
@@ -53,7 +53,6 @@
                          ^IPersistentVector cursor
                          ^Atom lookups
                          root]
-
   (get [this k not-found]
        (let [lookup-key (conj cursor k)
              v (type-aware-get-in value lookup-key not-found)
@@ -75,9 +74,12 @@
            (mapstache renderer value lookup-key lookups root)
 
            (instance? IPersistentCollection v)
-             (let [new-ms (mapstache renderer (update-in value lookup-key vec) lookup-key lookups root)]
-               (map-indexed
-                 (fn [idx _] (get new-ms idx)) v))
+           (let [new-ms (mapstache renderer value lookup-key lookups root)
+                 new-value (map (fn [idx] (get new-ms idx)) (range (count v)))]
+             (cond
+               (vector? v) (vec new-value)
+               (set? v) (set new-value)
+               :else new-value))
 
            :else v)))
 
@@ -94,6 +96,6 @@
 
 (defn mapstache
   ([renderer value]
-     (mapstache renderer value [] (atom []) nil))
+   (mapstache renderer value [] (atom []) nil))
   ([renderer value cursor lookups root]
-     (Mapstache. renderer value cursor lookups root)))
+   (Mapstache. renderer value cursor lookups root)))

--- a/test/matross/mapstache_test.clj
+++ b/test/matross/mapstache_test.clj
@@ -87,7 +87,17 @@
 
   (testing "I can call `rest` on a Mapstache"
     (let [[m ms] (matching-maps {:a "value"})]
-      (is (= (rest ms) (rest m))))))
+      (is (= (rest ms) (rest m)))))
+  (testing "get-in behaves like it does on a normal map"
+    (let [[m ms] (matching-maps {:a '(1 2 3)})]
+      (is (= (get-in ms [:a 1]) (get-in m [:a 1])))
+      (is (= (get-in ms [:a 10]) (get-in m [:a 10]))))
+    (let [[m ms] (matching-maps {:a [1 2 3]})]
+      (is (= (get-in ms [:a 10]) (get-in m [:a 10])))
+      (is (= (get-in ms [:a 1]) (get-in m [:a 1]))))
+    (let [[m ms] (matching-maps {:a #{1 2 3}})]
+      (is (= (get-in ms [:a 10]) (get-in m [:a 10])))
+      (is (= (get-in ms [:a 1]) (get-in m [:a 1])))) ))
 
 (deftest mapstache-behavior
   (testing "Querying maps wraps the value in a Mapstache"


### PR DESCRIPTION
So, this brings the external behavior of mapstache more in line with the behavior of a normal map, but it feels a little hacky/imprecise. I can't think of a better way right now to guarantee that the type that goes in is the type that comes out.
